### PR TITLE
Enhance GitHub Actions Workflow for Comprehensive Project Rendering

### DIFF
--- a/.github/workflows/render-rmd.yml
+++ b/.github/workflows/render-rmd.yml
@@ -49,48 +49,61 @@ jobs:
         run: |
           quarto add coatless/quarto-webr --no-prompt
 
-      - name: Install R Packages using pak
+      - name: Debug Quarto webr Extension
         run: |
-          install.packages("pak", repos = "https://cloud.r-project.org")
-          pak::pkg_install(c("knitr", "rmarkdown", "dplyr", "ggplot2", "tidyr", "openintro", "pkgdown"))
-        shell: Rscript {0}
+          echo "Listing Quarto webr extension files:"
+          ls -la _extensions/coatless/webr/
+          echo "Contents of _extension.yml:"
+          cat _extensions/coatless/webr/_extension.yml
+
+      - name: Install R Packages (for Quarto Rendering and pkgdown)
+        run: |
+          R -e "install.packages(c('knitr', 'rmarkdown', 'dplyr', 'ggplot2', 'tidyr', 'openintro', 'pkgdown'), dependencies=TRUE)"
+
+      - name: Verify R Package Installation
+        run: |
+          R -e "installed.packages()"
 
       - name: List All Files
         run: |
           echo "Files to process:"
-          find . -type f -not -path "./rendered_output/*" -not -path "./.git/*" -not -name "*.html" -ls || echo "No files found"
+          find . -type f \
+            -not -path "./rendered_output/*" \
+            -not -path "./.git/*" \
+            -not -path "./_extensions/*" \
+            -not -name "*.html" -ls || echo "No files found"
 
       - name: Render Markdown and Quarto Files, Copy Others
         run: |
           mkdir -p rendered_output
           quarto check install
-          find . -type f -not -path "./rendered_output/*" -not -path "./.git/*" -not -name "*.html" | while read -r file; do
+          find . -type f \
+            -not -path "./rendered_output/*" \
+            -not -path "./.git/*" \
+            -not -path "./_extensions/*" \
+            -not -name "*.html" | while read -r file; do
             if [ -f "$file" ]; then
-              case "$file" in
-                *README.md|*CODE_OF_CONDUCT.md|*LICENSE.md)
-                  echo "Skipping $file..."
-                  continue
-                  ;;
-              esac
-
               mkdir -p "rendered_output/$(dirname "$file")"
-
               if [[ "$file" == *.qmd ]]; then
                 echo "Rendering Quarto file $file..."
-                quarto render "$file" --output-dir "rendered_output/$(dirname "$file")" || {
-                  echo "::error file=$file::Failed to render Quarto file"
+                quarto render "$file" --output-dir "rendered_output/$(dirname "$file")"
+                if [ $? -ne 0 ]; then
+                  echo "Failed to render $file"
                   exit 1
-                }
-              elif [[ "$file" == *.md ]]; then
+                fi
+              elif [[ "$file" == *.md && "$file" != *README.md && "$file" != *CODE_OF_CONDUCT.md && "$file" != *LICENSE.md ]]; then
                 echo "Rendering Markdown file $file..."
-                quarto render "$file" --output-dir "rendered_output/$(dirname "$file")" || {
-                  echo "::error file=$file::Failed to render Markdown file"
+                quarto render "$file" --output-dir "rendered_output/$(dirname "$file")"
+                if [ $? -ne 0 ]; then
+                  echo "Failed to render $file"
                   exit 1
-                }
+                fi
               else
                 echo "Copying $file..."
                 cp "$file" "rendered_output/$file"
               fi
+            else
+              echo "No files found in project"
             fi
           done
         env:
@@ -98,19 +111,15 @@ jobs:
 
       - name: Build pkgdown Site
         run: |
-          R -e "pkgdown::build_site(dest_dir = 'rendered_output/docs')"
+          R -e "pkgdown::build_site(dest = 'rendered_output/docs')"
         env:
           R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
 
       - name: Debug Render Failure
         if: failure()
         run: |
-          echo "Rendered Output Contents:"
           ls -la rendered_output/ || echo "No rendered_output directory"
-          echo "Looking for log files..."
-          find . -name "*.log" -exec echo "--- {} ---" \; -exec cat {} \;
-          echo "Scanning .qmd files for Errors:"
-          grep -i -r "error" ./*.qmd || echo "No errors found in .qmd files"
+          find . -name "*.log" -exec cat {} \;
 
       - name: Deploy Entire Project to GitHub Pages
         if: success() && github.event_name != 'pull_request'

--- a/.github/workflows/render-rmd.yml
+++ b/.github/workflows/render-rmd.yml
@@ -32,7 +32,9 @@ jobs:
             libjpeg-dev \
             libfreetype6-dev \
             libharfbuzz-dev \
-            libfribidi-dev
+            libfribidi-dev \
+            libfontconfig1-dev \
+            libmagick++-dev
 
       - name: Setup Node.js
         uses: actions/setup-node@v3
@@ -58,7 +60,7 @@ jobs:
 
       - name: Install R Packages (for Quarto Rendering and pkgdown)
         run: |
-          R -e "install.packages(c('knitr', 'rmarkdown', 'dplyr', 'ggplot2', 'tidyr', 'openintro', 'pkgdown'), dependencies=TRUE)"
+          R -e "install.packages(c('knitr', 'rmarkdown', 'dplyr', 'ggplot2', 'tidyr', 'openintro', 'pkgdown', 'ragg', 'units', 'magick', 'systemfonts', 'textshaping', 'svglite', 'sf'), dependencies=TRUE)"
 
       - name: Verify R Package Installation
         run: |

--- a/.github/workflows/render-rmd.yml
+++ b/.github/workflows/render-rmd.yml
@@ -26,6 +26,11 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y libcurl4-openssl-dev libssl-dev libxml2-dev
 
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '16'
+
       - name: Install Quarto
         run: |
           curl -sSL https://github.com/quarto-dev/quarto-cli/releases/download/v1.5.56/quarto-1.5.56-linux-amd64.deb -o quarto.deb
@@ -35,6 +40,13 @@ jobs:
       - name: Install Quarto webr Extension
         run: |
           quarto add coatless/quarto-webr --no-prompt
+
+      - name: Debug Quarto webr Extension
+        run: |
+          echo "Listing Quarto webr extension files:"
+          ls -la _extensions/coatless/webr/
+          echo "Contents of _extension.yml:"
+          cat _extensions/coatless/webr/_extension.yml
 
       - name: Install R Packages (for Quarto Rendering and pkgdown)
         run: |

--- a/.github/workflows/render-rmd.yml
+++ b/.github/workflows/render-rmd.yml
@@ -24,7 +24,15 @@ jobs:
       - name: Install System Dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y libcurl4-openssl-dev libssl-dev libxml2-dev
+          sudo apt-get install -y \
+            libcurl4-openssl-dev \
+            libssl-dev \
+            libxml2-dev \
+            libpng-dev \
+            libjpeg-dev \
+            libfreetype6-dev \
+            libharfbuzz-dev \
+            libfribidi-dev
 
       - name: Setup Node.js
         uses: actions/setup-node@v3
@@ -64,6 +72,7 @@ jobs:
       - name: Render Markdown and Quarto Files, Copy Others
         run: |
           mkdir -p rendered_output
+          quarto check install
           find . -type f -not -path "./rendered_output/*" -not -path "./.git/*" -not -name "*.html" | while read -r file; do
             if [ -f "$file" ]; then
               mkdir -p "rendered_output/$(dirname "$file")"

--- a/.github/workflows/render-rmd.yml
+++ b/.github/workflows/render-rmd.yml
@@ -47,16 +47,23 @@ jobs:
       - name: List All Files
         run: |
           echo "Files to process:"
-          find . -type f -not -path "./rendered_output/*" -not -path "./.git/*" -not -path "./docs/*" -ls || echo "No files found"
+          find . -type f -not -path "./rendered_output/*" -not -path "./.git/*" -not -name "*.html" -ls || echo "No files found"
 
       - name: Render Markdown and Quarto Files, Copy Others
         run: |
           mkdir -p rendered_output
-          find . -type f -not -path "./rendered_output/*" -not -path "./.git/*" -not -path "./docs/*" | while read -r file; do
+          find . -type f -not -path "./rendered_output/*" -not -path "./.git/*" -not -name "*.html" | while read -r file; do
             if [ -f "$file" ]; then
               mkdir -p "rendered_output/$(dirname "$file")"
-              if [[ "$file" == *.qmd || "$file" == *.md ]]; then
-                echo "Rendering $file..."
+              if [[ "$file" == *.qmd ]]; then
+                echo "Rendering Quarto file $file..."
+                quarto render "$file" --output-dir "rendered_output/$(dirname "$file")"
+                if [ $? -ne 0 ]; then
+                  echo "Failed to render $file"
+                  exit 1
+                fi
+              elif [[ "$file" == *.md && "$file" != *README.md && "$file" != *CODE_OF_CONDUCT.md && "$file" != *LICENSE.md ]]; then
+                echo "Rendering Markdown file $file..."
                 quarto render "$file" --output-dir "rendered_output/$(dirname "$file")"
                 if [ $? -ne 0 ]; then
                   echo "Failed to render $file"

--- a/.github/workflows/render-rmd.yml
+++ b/.github/workflows/render-rmd.yml
@@ -49,20 +49,11 @@ jobs:
         run: |
           quarto add coatless/quarto-webr --no-prompt
 
-      - name: Debug Quarto webr Extension
+      - name: Install R Packages using pak
         run: |
-          echo "Listing Quarto webr extension files:"
-          ls -la _extensions/coatless/webr/
-          echo "Contents of _extension.yml:"
-          cat _extensions/coatless/webr/_extension.yml
-
-      - name: Install R Packages (for Quarto Rendering and pkgdown)
-        run: |
-          R -e "install.packages(c('knitr', 'rmarkdown', 'dplyr', 'ggplot2', 'tidyr', 'openintro', 'pkgdown'), dependencies=TRUE)"
-
-      - name: Verify R Package Installation
-        run: |
-          R -e "installed.packages()"
+          install.packages("pak", repos = "https://cloud.r-project.org")
+          pak::pkg_install(c("knitr", "rmarkdown", "dplyr", "ggplot2", "tidyr", "openintro", "pkgdown"))
+        shell: Rscript {0}
 
       - name: List All Files
         run: |
@@ -75,27 +66,31 @@ jobs:
           quarto check install
           find . -type f -not -path "./rendered_output/*" -not -path "./.git/*" -not -name "*.html" | while read -r file; do
             if [ -f "$file" ]; then
+              case "$file" in
+                *README.md|*CODE_OF_CONDUCT.md|*LICENSE.md)
+                  echo "Skipping $file..."
+                  continue
+                  ;;
+              esac
+
               mkdir -p "rendered_output/$(dirname "$file")"
+
               if [[ "$file" == *.qmd ]]; then
                 echo "Rendering Quarto file $file..."
-                quarto render "$file" --output-dir "rendered_output/$(dirname "$file")"
-                if [ $? -ne 0 ]; then
-                  echo "Failed to render $file"
+                quarto render "$file" --output-dir "rendered_output/$(dirname "$file")" || {
+                  echo "::error file=$file::Failed to render Quarto file"
                   exit 1
-                fi
-              elif [[ "$file" == *.md && "$file" != *README.md && "$file" != *CODE_OF_CONDUCT.md && "$file" != *LICENSE.md ]]; then
+                }
+              elif [[ "$file" == *.md ]]; then
                 echo "Rendering Markdown file $file..."
-                quarto render "$file" --output-dir "rendered_output/$(dirname "$file")"
-                if [ $? -ne 0 ]; then
-                  echo "Failed to render $file"
+                quarto render "$file" --output-dir "rendered_output/$(dirname "$file")" || {
+                  echo "::error file=$file::Failed to render Markdown file"
                   exit 1
-                fi
+                }
               else
                 echo "Copying $file..."
                 cp "$file" "rendered_output/$file"
               fi
-            else
-              echo "No files found in project"
             fi
           done
         env:
@@ -103,15 +98,19 @@ jobs:
 
       - name: Build pkgdown Site
         run: |
-          R -e "pkgdown::build_site(dest = 'rendered_output/docs')"
+          R -e "pkgdown::build_site(dest_dir = 'rendered_output/docs')"
         env:
           R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
 
       - name: Debug Render Failure
         if: failure()
         run: |
+          echo "Rendered Output Contents:"
           ls -la rendered_output/ || echo "No rendered_output directory"
-          find . -name "*.log" -exec cat {} \;  # Look for Quarto logs
+          echo "Looking for log files..."
+          find . -name "*.log" -exec echo "--- {} ---" \; -exec cat {} \;
+          echo "Scanning .qmd files for Errors:"
+          grep -i -r "error" ./*.qmd || echo "No errors found in .qmd files"
 
       - name: Deploy Entire Project to GitHub Pages
         if: success() && github.event_name != 'pull_request'

--- a/.github/workflows/render-rmd.yml
+++ b/.github/workflows/render-rmd.yml
@@ -111,6 +111,10 @@ jobs:
         env:
           QUARTO_LOG_LEVEL: DEBUG
 
+      - name: Install Pandoc
+        run: |
+          sudo apt-get install -y pandoc
+
       - name: Build pkgdown Site
         run: |
           mkdir -p rendered_output/docs

--- a/.github/workflows/render-rmd.yml
+++ b/.github/workflows/render-rmd.yml
@@ -1,4 +1,4 @@
-name: Render Quarto Vignettes
+name: Render Entire Project
 
 on:
   push:
@@ -36,53 +36,64 @@ jobs:
         run: |
           quarto add coatless/quarto-webr --no-prompt
 
-      - name: Install R Packages (for Quarto Rendering)
+      - name: Install R Packages (for Quarto Rendering and pkgdown)
         run: |
-          R -e "install.packages(c('knitr', 'rmarkdown', 'dplyr', 'ggplot2', 'tidyr', 'openintro'), dependencies=TRUE)"
-        # Added common packages likely needed for your vignettes
+          R -e "install.packages(c('knitr', 'rmarkdown', 'dplyr', 'ggplot2', 'tidyr', 'openintro', 'pkgdown'), dependencies=TRUE)"
 
       - name: Verify R Package Installation
         run: |
           R -e "installed.packages()"
 
-      - name: List Vignette Files
+      - name: List All Files
         run: |
-          echo "Vignette files to render:"
-          ls -l vignettes/*.qmd || echo "No .qmd files found"
+          echo "Files to process:"
+          find . -type f -not -path "./rendered_output/*" -not -path "./.git/*" -not -path "./docs/*" -ls || echo "No files found"
 
-      - name: Render All Vignettes
+      - name: Render Markdown and Quarto Files, Copy Others
         run: |
-          mkdir -p rendered_vignettes
-          for file in vignettes/*.qmd; do
+          mkdir -p rendered_output
+          find . -type f -not -path "./rendered_output/*" -not -path "./.git/*" -not -path "./docs/*" | while read -r file; do
             if [ -f "$file" ]; then
-              echo "Rendering $file..."
-              quarto render "$file" --output-dir rendered_vignettes
-              if [ $? -ne 0 ]; then
-                echo "Failed to render $file"
-                exit 1
+              mkdir -p "rendered_output/$(dirname "$file")"
+              if [[ "$file" == *.qmd || "$file" == *.md ]]; then
+                echo "Rendering $file..."
+                quarto render "$file" --output-dir "rendered_output/$(dirname "$file")"
+                if [ $? -ne 0 ]; then
+                  echo "Failed to render $file"
+                  exit 1
+                fi
+              else
+                echo "Copying $file..."
+                cp "$file" "rendered_output/$file"
               fi
             else
-              echo "No .qmd files found in vignettes/"
+              echo "No files found in project"
             fi
           done
         env:
           QUARTO_LOG_LEVEL: DEBUG
 
+      - name: Build pkgdown Site
+        run: |
+          R -e "pkgdown::build_site(dest = 'rendered_output/docs')"
+        env:
+          R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
+
       - name: Debug Render Failure
         if: failure()
         run: |
-          ls -la rendered_vignettes/ || echo "No rendered_vignettes directory"
+          ls -la rendered_output/ || echo "No rendered_output directory"
           find . -name "*.log" -exec cat {} \;  # Look for Quarto logs
 
-      - name: Deploy Rendered Vignettes to GitHub Pages
+      - name: Deploy Entire Project to GitHub Pages
         if: success() && github.event_name != 'pull_request'
         uses: JamesIves/github-pages-deploy-action@v4
         with:
           branch: gh-pages
-          folder: rendered_vignettes
+          folder: rendered_output
           clean: true
 
       - name: Notify on Failure
         if: failure()
         run: |
-          echo "::error:: Vignette rendering failed! Check logs in GitHub Actions."
+          echo "::error:: Project rendering failed! Check logs in GitHub Actions."

--- a/.github/workflows/render-rmd.yml
+++ b/.github/workflows/render-rmd.yml
@@ -113,7 +113,9 @@ jobs:
 
       - name: Build pkgdown Site
         run: |
-          R -e "pkgdown::build_site(dest = 'rendered_output/docs')"
+          mkdir -p rendered_output/docs
+          R -e "pkgdown::build_site()"
+          cp -r docs/* rendered_output/docs/
         env:
           R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
 


### PR DESCRIPTION
**📦 Description**
This PR improves the` render-rmd.yml` workflow [for the issue here](https://github.com/CUNY-epibios/PUBH614/issues/1) to ensure all updateable files in the project are rendered or copied appropriately and deployed to GitHub Pages. It builds on the previous addition of a `pkgdown `build step and introduces additional reliability through `Pandoc` installation. The workflow now handles source files more comprehensively, rendering where necessary and avoiding unnecessary processing of specific Markdown files.

**✨ Changes**
Added `Pandoc` installation to ensure compatibility and successful rendering of `.md `and `.qmd` files in various environments.

Included `pkgdown` in the R packages installation list and added a step to run `pkgdown::build_site()`, outputting to `rendered_output/docs/`.

**Updated file processing logic to:**

Include files from the docs/ directory by excluding only .html files (previously excluded the whole directory).

Render `.qmd` files with `Quarto`.

Selectively render `.md` files:

`README.md`, `CODE_OF_CONDUCT.md,` and `LICENSE.md` are copied as raw files.

**All other** `.md `files are rendered with Quarto.

Copy all other files (`e.g., .R, images, datasets`) into r`endered_output/`, preserving the directory structure.

Deploy the `complete rendered_output/ directory` to the `gh-pages` branch via GitHub Pages.

**✅ Testing**
Verified that Quarto files `(.qmd)` and applicable Markdown files `(.md)` render correctly.

 Confirmed that `README.md`, `CODE_OF_CONDUCT.md`, and `LICENSE.md` are copied without rendering.

Ensured updates to `.R` files and `pkgdown.yml `are reflected in the generated site.

Checked that **static assets** `(e.g., images, CSS)` and **datasets** `(e.g., .csv)` are copied correctly.

Validated that the deployed GitHub Pages site contains all expected updates across the project.

**🔗 Related Issues**
Addresses the need to process all updateable project files, including those within `docs/`.

Prevents unnecessary rendering of Markdown files meant to be presented as raw text.

Improves workflow robustness through explicit Pandoc installation.

